### PR TITLE
Update hardhat.config.js to removed the hardcoded Alchemy Key

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,7 +1,7 @@
 require("@nomiclabs/hardhat-waffle");
 require("dotenv").config();
 
-const ALCHEMY_URL = "https://eth-sepolia.g.alchemy.com/v2/ffkZa-uXE8b89z3snYfDz";
+const ALCHEMY_URL = process.env.ALCHEMY_URL;
 const { PRIVATE_KEY } = process.env;
 
 module.exports = {


### PR DESCRIPTION
### Summary

This pull request addresses **Issue #1: [Security] Hardcoded Alchemy API Key Exposure in `hardhat.config.js`**.

### Changes Made
- Removed hardcoded Alchemy API key:
 ```javascript
  - const ALCHEMY_URL = "https://eth-sepolia.g.alchemy.com/v2/ffkZa-uXE8b89z3snYfDz";
  + const ALCHEMY_URL = process.env.ALCHEMY_URL;
```

* Retained support for `PRIVATE_KEY` via `.env`.
* Added recommendation to include `.env` in `.gitignore` (if not already present).

### Why This Fix?

* Prevents unauthorized usage of the exposed RPC key.
* Protects against potential rate-limit abuse and denial of service.
* Aligns the project with **best practices for secret management**.

### Next Steps for Repository Owner

1. **Generate a new Alchemy API key** via Alchemy dashboard.
2. Add it to `.env`:

   ```env
   ALCHEMY_URL="https://eth-sepolia.g.alchemy.com/v2/YOUR_NEW_KEY"
   PRIVATE_KEY=your_private_key_here
   ```
3. Merge this PR to mitigate the exposure.

### Linked Issue

Closes #1

### Notes

> **This change was made as part of responsible disclosure to prevent misuse of the exposed key.**

---
